### PR TITLE
訳語の統一とマークアップの修正

### DIFF
--- a/book/B-embedding-git/sections/jgit.asc
+++ b/book/B-embedding-git/sections/jgit.asc
@@ -96,7 +96,7 @@ The builder has a fluent API for providing all the things it needs to find a Git
 It can use environment variables (`.readEnvironment()`), start from a place in the working directory and search (`.setWorkTree(…).findGitDir()`), or just open a known `.git` directory as above.
 //////////////////////////
 `FileRepositoryBuilder` は洗練されたAPIが備わっており、リポジトリの場所が分かっているにしろいないにしろ、Gitのリポジトリを見つけるのに必要な処理はすべて提供されています。
-ここでは、環境変数を使う (`.readEnvironment()`)、ワーキングディレクトリ中のどこかを起点として検索をする(`.setWorkTree(…).findGitDir()`)、上の例のように単に既知の `.git` ディレクトリを開く、といった方法が使用できます。
+ここでは、環境変数を使う (`.readEnvironment()`)、作業ディレクトリ中のどこかを起点として検索をする(`.setWorkTree(…).findGitDir()`)、上の例のように単に既知の `.git` ディレクトリを開く、といった方法が使用できます。
 
 //////////////////////////
 Once you have a `Repository` instance, you can do all sorts of things with it.

--- a/book/B-embedding-git/sections/libgit2.asc
+++ b/book/B-embedding-git/sections/libgit2.asc
@@ -215,7 +215,7 @@ The code below is borrowed from the set of backend examples provided by the Libg
 Here's how a custom backend for the object database is set up:
 //////////////////////////
 バックエンドがどのように機能するか見てみましょう。
-次のコードは、Libgit2チームが提供しているサンプル（https://github.com/libgit2/libgit2-backends[] から取得できます）から拝借しています。
+次のコードは、Libgit2チームが提供しているサンプル（ https://github.com/libgit2/libgit2-backends[] から取得できます）から拝借しています。
 オブジェクトデータベース用のカスタムバックエンドを設定する方法を示しています。
 
 [source,c]


### PR DESCRIPTION
- 訳語（ワーキングディレクトリ→作業ディレクトリ）の修正を行いました。
- PDF版を見てみたらリンクが正しく張れていないところがあったので修正しました。
