### PR TITLE
Fix a link in the translation notes

### DIFF
--- a/TRANSLATION_NOTES.asc
+++ b/TRANSLATION_NOTES.asc
@@ -26,7 +26,7 @@ Pro Git第2版の翻訳作業はGitHubを使って管理していきます。201
   - 「第◯章の作業はじめます」というissueをたてる
   - Work In ProgressのPull Requestを送る
 
-https://github.com/progit/progit2-ja/releases[Releases] に掲載されているのは*翻訳済みの章*、https://github.com/progit/progit2-ja/labels/wip[wipタグがついているissue] は*現在翻訳中の章*です。確認して、作業が重複することのないようにしてください。
+https://github.com/progit/progit2-ja/releases[Releases] に掲載されているのは*翻訳済みの章*、 https://github.com/progit/progit2-ja/labels/wip[wipタグがついているissue] は*現在翻訳中の章*です。確認して、作業が重複することのないようにしてください。
 
 ==== 翻訳する
 


### PR DESCRIPTION
GitHub上ではスペースがないと正しくリンクされていないようでしたので修正しました。