### PR TITLE
「10.3 Gitの参照」5箇所を改訳

### DIFF
--- a/book/10-git-internals/sections/refs.asc
+++ b/book/10-git-internals/sections/refs.asc
@@ -244,7 +244,7 @@ Also notice that it doesn't need to point to a commit; you can tag any Git objec
 In the Git source code, for example, the maintainer has added their GPG public key as a blob object and then tagged it.
 You can view the public key by running this in a clone of the Git repository:
 //////////////////////////
-オブジェクトエントリはあなたがタグ付けしたコミットの SHA-1 ハッシュ値をポイントすることに注意してください。またそれがコミットをポイントする必要がないことに注意してください。あらゆる Git オブジェクトに対してタグ付けをすることができます。例えば、Git のソースコードの保守では GPG 公開鍵をブロブオブジェクトとして追加して、それからタグ付けをします。Gitリポジトリのクローン上で、以下のように実行することで公開鍵を閲覧することができます。
+`object` の項目が、あなたがタグ付けしたコミットのSHA-1ハッシュ値をポイントしていることに注意してください。また、この項目が必ずしもコミットだけをポイントするものではないことも覚えておいてください。あらゆる Git オブジェクトに対してタグを付けることができます。例えば Git のソースコードリポジトリでは、メンテナが自分の GPG 公開鍵をブロブオブジェクトとして追加し、そのオブジェクトにタグを付けています。Git リポジトリのクローン上で、以下のコマンドを実行すると公開鍵を閲覧することができます。
 
 [source,console]
 ----
@@ -254,7 +254,7 @@ $ git cat-file blob junio-gpg-pub
 //////////////////////////
 The Linux kernel repository also has a non-commit-pointing tag object – the first tag created points to the initial tree of the import of the source code.
 //////////////////////////
-Linuxカーネルのリポジトリは、さらに、非コミットポインティング（non-commit-pointing）タグオブジェクトを持っています。このタグオブジェクトは、最初のタグが作られるとソースコードのインポートの最初のツリーをポイントします。
+Linux カーネルのリポジトリもまた、`object` 項目でコミット以外をポイントしているタグオブジェクトを持っています。これは最初のタグオブジェクトであり、最初にソースコードをインポートしたときの初期ツリーオブジェクトをポイントしています。
 
 //////////////////////////
 ==== Remotes

--- a/book/10-git-internals/sections/refs.asc
+++ b/book/10-git-internals/sections/refs.asc
@@ -137,7 +137,7 @@ ref: refs/heads/test
 //////////////////////////
 When you run `git commit`, it creates the commit object, specifying the parent of that commit object to be whatever SHA-1 value the reference in HEAD points to.
 //////////////////////////
-`git commit` を実行すると、コミットオブジェクトが作られます。HEADにある参照先の SHA-1ハッシュ値が何であれ、そのコミットオブジェクトの親が参照先に指定されます。
+`git commit` を実行するとコミットオブジェクトが作られますが、そのときコミットオブジェクトの親として、HEADが指し示す参照先のSHA-1ハッシュ値が指定されます。
 
 //////////////////////////
 You can also manually edit this file, but again a safer command exists to do so: `symbolic-ref`.

--- a/book/10-git-internals/sections/refs.asc
+++ b/book/10-git-internals/sections/refs.asc
@@ -185,7 +185,7 @@ The tag object is very much like a commit object – it contains a tagger, a dat
 The main difference is that a tag object generally points to a commit rather than a tree.
 It's like a branch reference, but it never moves – it always points to the same commit but gives it a friendlier name.
 //////////////////////////
-これで Git の主要な三つのオブジェクトを見終わったわけですが、タグという四つ目のオブジェクトがあります。タグオブジェクトはコミットオブジェクトにとても似ています。それには、タグ作成者（tagger）、日付、メッセージ、そしてポインタが含まれます。主な違いは、タグオブジェクトは通常ツリーではなくコミットを指し示すことです。タグオブジェクトはブランチの参照に似ていますが、決して変動しません。そのため常に同じコミットを示しますが、より親しみのある名前が与えられます。
+これで Git の主要な三つのオブジェクトを見終わったわけですが、タグという四つ目のオブジェクトがあります。タグオブジェクトはコミットオブジェクトにとても似ています。それには、タグ作成者、日付、メッセージ、そしてポインタが含まれます。主な違いは、タグオブジェクトは通常ツリーではなくコミットを指し示すことです。タグオブジェクトはブランチの参照に似ていますが、決して変動しません。そのため常に同じコミットを示しますが、より親しみのある名前が与えられます。
 
 //////////////////////////
 As discussed in <<_git_basics_chapter>>, there are two types of tags: annotated and lightweight.

--- a/book/10-git-internals/sections/refs.asc
+++ b/book/10-git-internals/sections/refs.asc
@@ -185,7 +185,7 @@ The tag object is very much like a commit object – it contains a tagger, a dat
 The main difference is that a tag object generally points to a commit rather than a tree.
 It's like a branch reference, but it never moves – it always points to the same commit but gives it a friendlier name.
 //////////////////////////
-これで Git の主要な三つのオブジェクトを見終わったわけですが、タグという四つ目のオブジェクトがあります。タグオブジェクトはコミットオブジェクトにとても似ています。それには、タガー（tagger）、日付、メッセージ、そしてポインタが含まれます。主な違いは、タグオブジェクトは通常ツリーではなくコミットを指し示すことです。タグオブジェクトはブランチの参照に似ていますが、決して変動しません。そのため常に同じコミットを示しますが、より親しみのある名前が与えられます。
+これで Git の主要な三つのオブジェクトを見終わったわけですが、タグという四つ目のオブジェクトがあります。タグオブジェクトはコミットオブジェクトにとても似ています。それには、タグ作成者（tagger）、日付、メッセージ、そしてポインタが含まれます。主な違いは、タグオブジェクトは通常ツリーではなくコミットを指し示すことです。タグオブジェクトはブランチの参照に似ていますが、決して変動しません。そのため常に同じコミットを示しますが、より親しみのある名前が与えられます。
 
 //////////////////////////
 As discussed in <<_git_basics_chapter>>, there are two types of tags: annotated and lightweight.

--- a/book/10-git-internals/sections/refs.asc
+++ b/book/10-git-internals/sections/refs.asc
@@ -296,6 +296,4 @@ Remote references differ from branches (`refs/heads` references) mainly in that 
 You can `git checkout` to one, but Git won't point HEAD at one, so you'll never update it with a `commit` command.
 Git manages them as bookmarks to the last known state of where those branches were on those servers.
 //////////////////////////
-リモート参照は、主に読み取り専用とみなされるという点において、ブランチ（`refs/heads` への参照）とは異なります。
-リモート参照に対して `git checkout` を行うことはできますが、GitはそのHEADを指すことはなく、したがって `commit` コマンドで更新することもできません。
-Gitは、リモート参照を、それらのブランチがかつてサーバー上に存在していた場所の最後に知られている状態を示すブックマークとして管理します。
+リモート参照は、特に読み取り専用とみなされる点において、ブランチ（`refs/heads` への参照）とは異なります。リモート参照に対して `git checkout` を行うことはできますが、Git はHEADの参照先をそのリモートにすることはなく、したがって `commit` コマンドでリモートを更新することもできません。Git はリモート参照を一種のブックマークとして管理します。つまり、最後に通信したとき、向こうのサーバー上でリモートブランチが置かれていた状態を指し示すブックマークということです。


### PR DESCRIPTION
`book/10-git-internals/sections/refs.asc` の5箇所を改訳しました（コミットとしては4回）。
詳細は各コミットメッセージをご参照ください。
お手数ですが、ご確認よろしくお願いいたします。