### PR TITLE
第3章：訳文を更新

### DIFF
--- a/book/03-git-branching/sections/remote-branches.asc
+++ b/book/03-git-branching/sections/remote-branches.asc
@@ -265,7 +265,7 @@ Checking out a local branch from a remote-tracking branch automatically creates 
 Tracking branches are local branches that have a direct relationship to a remote branch.
 If you're on a tracking branch and type `git pull`, Git automatically knows which server to fetch from and branch to merge into.
 //////////////////////////
-リモート追跡ブランチからローカルブランチにチェックアウトすると、``追跡ブランチ'' (あるいは ``上流ブランチ'') というブランチが自動的に作成されます。
+リモート追跡ブランチからローカルブランチにチェックアウトすると、``追跡ブランチ''  というブランチが自動的に作成されます(そしてそれが追跡するブランチを``上流ブランチ''といいます)。
 追跡ブランチとは、リモートブランチと直接のつながりを持つローカルブランチのことです。
 追跡ブランチ上で `git pull` を実行すると、Git は自動的に取得元のサーバーとブランチを判断します。
 


### PR DESCRIPTION
原文の変更に追従しました。

原文：

> Checking out a local branch from a remote-tracking branch automatically creates what is called a　\`\`tracking branch'' (or sometimes an \`\`upstream branch'').

↓

> Checking out a local branch from a remote-tracking branch automatically creates what is called a \`\`tracking branch'' (and the branch it tracks is called an \`\`upstream branch'')