### PR TITLE
Fix typos at hooks.asc

### DIFF
--- a/book/08-customizing-git/sections/hooks.asc
+++ b/book/08-customizing-git/sections/hooks.asc
@@ -14,7 +14,7 @@ You can use these hooks for all sorts of reasons.
 他のバージョンコントロールシステムと同じように、Gitにも特定のアクションが発生した時にカスタムスクリプトを叩く方法があります。
 このようなフックは、クライアントサイドとサーバーサイドの二つのグループに分けられます。
 クライアントサイドフックはコミットやマージといったクライアントでの操作の際に、サーバーサイドフックはプッシュされたコミットの受け取りといったネットワーク操作の際に、それぞれ実行されます。
-これらのフックは、さまざまなな目的に用いることができます。
+これらのフックは、さまざまな目的に用いることができます。
 
 //////////////////////////
 ==== Installing a Hook
@@ -111,7 +111,7 @@ After the entire commit process is completed, the `post-commit` hook runs.
 It doesn't take any parameters, but you can easily get the last commit by running `git log -1 HEAD`.
 Generally, this script is used for notification or something similar.
 //////////////////////////
-コミットプロセスが全て完了した後には、`post-commit`フックが実行されます。
+コミットプロセスが全て完了した後には、 `post-commit` フックが実行されます。
 このフックはパラメータを取りませんが、 `git log -1 HEAD` を実行することで直前のコミットを簡単に取り出すことができます。
 一般的にこのスクリプトは何かしらの通知といった目的に使用されます。
 


### PR DESCRIPTION
[8.3 Git のカスタマイズ - Git フック](https://git-scm.com/book/ja/v2/Git-%E3%81%AE%E3%82%AB%E3%82%B9%E3%82%BF%E3%83%9E%E3%82%A4%E3%82%BA-Git-%E3%83%95%E3%83%83%E3%82%AF)のページにて、2点 typo と思われる箇所を見つけましたので、
修正させていただきたいです。

issue: https://github.com/progit/progit2-ja/issues/106