### PR TITLE
Fix a wrong translation for "transferring data"

### DIFF
--- a/book/10-git-internals/sections/transfer-protocols.asc
+++ b/book/10-git-internals/sections/transfer-protocols.asc
@@ -206,7 +206,7 @@ The smart protocol is a more common method of transferring data, but it requires
 There are two sets of processes for transferring data: a pair for uploading data and a pair for downloading data.
 //////////////////////////
 dumbプロトコルはシンプルですが、少し非効率ですし、クライアントからサーバーへのデータの書き込みも行えません。
-データ移行においては、smartプロトコルの方がより一般的な手段です。ただし、リモート側にGitと対話できるプロセス – ローカルのデータを読んだり、クライアントが何を持っていて何が必要としているかを判別したり、それに応じたpackfileを生成したりできるプロセス – が必要です。
+データ転送においては、smartプロトコルの方がより一般的な手段です。ただし、リモート側にGitと対話できるプロセス – ローカルのデータを読んだり、クライアントが何を持っていて何が必要としているかを判別したり、それに応じたpackfileを生成したりできるプロセス – が必要です。
 データの転送には、プロセスを2セット使用します。データをアップロードするペアと、ダウンロードするペアです。
 
 


### PR DESCRIPTION
原文

> The smart protocol is a more common method of transferring data, but it requires [...]

- Original: https://git-scm.com/book/en/v2/Git-Internals-Transfer-Protocols#_the_smart_protocol
- ja Translation: https://git-scm.com/book/ja/v2/Git%E3%81%AE%E5%86%85%E5%81%B4-%E8%BB%A2%E9%80%81%E3%83%97%E3%83%AD%E3%83%88%E3%82%B3%E3%83%AB#_smart%E3%83%97%E3%83%AD%E3%83%88%E3%82%B3%E3%83%AB
