### PR TITLE
Insert spaces around backticks for markups to be correctly detected

### DIFF
--- a/book/08-customizing-git/sections/hooks.asc
+++ b/book/08-customizing-git/sections/hooks.asc
@@ -91,7 +91,7 @@ This hook takes a few parameters: the path to the file that holds the commit mes
 This hook generally isn't useful for normal commits; rather, it's good for commits where the default message is auto-generated, such as templated commit messages, merge commits, squashed commits, and amended commits.
 You may use it in conjunction with a commit template to programmatically insert information.
 //////////////////////////
-`prepare-commit-msg`フックは、コミットメッセージエディターが起動する直前、デフォルトメッセージが生成された直後に実行されます。
+`prepare-commit-msg` フックは、コミットメッセージエディターが起動する直前、デフォルトメッセージが生成された直後に実行されます。
 このフックでは、デフォルトメッセージを、コミットの作者の目に触れる前に編集できます。
 このフックにはパラメータがあり、その時点でのコミットメッセージを保存したファイルへのパス、コミットのタイプ、さらにamendされたコミットの場合はコミットの SHA-1 をパラメータとして取ります。
 このフックは普段のコミットにおいてはあまり有用ではありませんが、テンプレートが用意されているコミットメッセージ・mergeコミット・squashコミット・amendコミットのような、デフォルトメッセージが自動生成されるコミットにおいて効果を発揮します。
@@ -111,7 +111,7 @@ After the entire commit process is completed, the `post-commit` hook runs.
 It doesn't take any parameters, but you can easily get the last commit by running `git log -1 HEAD`.
 Generally, this script is used for notification or something similar.
 //////////////////////////
-コミットプロセスが全て完了した後には、`post-commit`フックが実行されます。
+コミットプロセスが全て完了した後には、 `post-commit` フックが実行されます。
 このフックはパラメータを取りませんが、 `git log -1 HEAD` を実行することで直前のコミットを簡単に取り出すことができます。
 一般的にこのスクリプトは何かしらの通知といった目的に使用されます。
 


### PR DESCRIPTION
Hi,

This is a correction of an issue that some markups are not detected in book/08-customizing-git/sections/hooks.asc.
Could you please review?

Many thanks,

-noritada
