### PR TITLE
Add spaces to apply markdown decoration and Remove unnecessary spaces

### DIFF
--- a/book/02-git-basics/sections/undoing.asc
+++ b/book/02-git-basics/sections/undoing.asc
@@ -95,7 +95,7 @@ Changes to be committed:
 Right below the ``Changes to be committed'' text, it says use `git reset HEAD <file>...` to unstage.
 So, let's use that advice to unstage the `CONTRIBUTING.md` file:
 //////////////////////////
-``Changes to be committed'' の直後に、"use `git reset HEAD <file>...` to unstage" と書かれています。このアドバイスに従って、`CONTRIBUTING.md` ファイルのステージを解除してみましょう。
+"Changes to be committed" の直後に、"use `git reset HEAD <file>...` to unstage" と書かれています。このアドバイスに従って、`CONTRIBUTING.md` ファイルのステージを解除してみましょう。
 
 [source,console]
 ----
@@ -131,7 +131,7 @@ Calling `git reset` without an option is not dangerous - it only touches your st
 =====
 //////////////////////////
 =====
-`git reset` は、危険なコマンドに_なりえます_。その条件は、「`--hard`オプションをつけて実行すること」です。
+`git reset` は、危険なコマンドに　_なりえます_。その条件は、「`--hard` オプションをつけて実行すること」です。
 ただし、上述の例はそうしておらず、作業ディレクトリにあるファイルに変更は加えられていません。
 `git reset` をオプションなしで実行するのは危険ではありません。
 ステージングエリアのファイルに変更が加えられるだけなのです。
@@ -141,7 +141,7 @@ Calling `git reset` without an option is not dangerous - it only touches your st
 For now this magic invocation is all you need to know about the `git reset` command.
 We'll go into much more detail about what `reset` does and how to master it to do really interesting things in <<ch07-git-tools#r_git_reset>>.
 //////////////////////////
-今のところは、`git reset`については上記の魔法の呪文を知っておけば十分でしょう。<<ch07-git-tools#r_git_reset>>で、より詳細に、`reset`の役割と使いこなし方について説明します。色々とおもしろいことができるようになりますよ。
+今のところは、`git reset` については上記の魔法の呪文を知っておけば十分でしょう。<<ch07-git-tools#r_git_reset>>で、より詳細に、`reset` の役割と使いこなし方について説明します。色々とおもしろいことができるようになりますよ。
 
 //////////////////////////
 ==== Unmodifying a Modified File
@@ -172,7 +172,7 @@ Changes not staged for commit:
 It tells you pretty explicitly how to discard the changes you've made.
 Let's do what it says:
 //////////////////////////
-とても明確に、変更を取り消す方法が書かれています 。
+とても明確に、変更を取り消す方法が書かれています。
 ではそのとおりにしてみましょう。
 
 [source,console]
@@ -201,7 +201,7 @@ Don't ever use this command unless you absolutely know that you don't want the f
 =====
 //////////////////////////
 =====
-ここで理解しておくべきなのが、`git checkout -- [file]`は危険なコマンドだ、ということです。
+ここで理解しておくべきなのが、`git checkout -- [file]` は危険なコマンドだ、ということです。
 あなたがファイルに加えた変更はすべて消えてしまいます。変更した内容を、別のファイルで上書きしたのと同じことになります。そのファイルが不要であることが確実にわかっているとき以外は、このコマンドを使わないようにしましょう。
 =====
 


### PR DESCRIPTION
` や _ の直後にスペースが不足していたためMarkdownの記法として認識されていなかった部分を修正しました。
また、不要なスペースを削除しました。