### PR TITLE
Insert spaces around backticks for markups to be correctly detected

### DIFF
--- a/book/02-git-basics/sections/getting-a-repository.asc
+++ b/book/02-git-basics/sections/getting-a-repository.asc
@@ -81,7 +81,7 @@ You clone a repository with `git clone [url]`.(((git commands, clone)))
 For example, if you want to clone the Git linkable library called libgit2, you can do so like this:
 //////////////////////////
 リポジトリをクローンするには `git clone [url]` とします。(((git commands, clone)))
-たとえば、多言語へのバインディングが可能なGitライブラリであるlibgitをクローンする場合は次のようになります。
+たとえば、多言語へのバインディングが可能なGitライブラリであるlibgit2をクローンする場合は次のようになります。
 
 [source,console]
 ----

--- a/book/02-git-basics/sections/getting-a-repository.asc
+++ b/book/02-git-basics/sections/getting-a-repository.asc
@@ -78,10 +78,10 @@ Subversion などの他の VCS を使っている人なら「"checkout" じゃ�
 
 //////////////////////////
 You clone a repository with `git clone [url]`.(((git commands, clone)))
-For example, if you want to clone the Git linkable library called libgit2, you can do so like this:
+For example, if you want to clone the Git linkable library called `libgit2`, you can do so like this:
 //////////////////////////
 リポジトリをクローンするには `git clone [url]` とします。(((git commands, clone)))
-たとえば、多言語へのバインディングが可能なGitライブラリであるlibgit2をクローンする場合は次のようになります。
+たとえば、多言語へのバインディングが可能なGitライブラリである `libgit2` をクローンする場合は次のようになります。
 
 [source,console]
 ----
@@ -89,13 +89,13 @@ $ git clone https://github.com/libgit2/libgit2
 ----
 
 //////////////////////////
-That creates a directory named ``libgit2'', initializes a `.git` directory inside it, pulls down all the data for that repository, and checks out a working copy of the latest version.
+That creates a directory named `libgit2`, initializes a `.git` directory inside it, pulls down all the data for that repository, and checks out a working copy of the latest version.
 If you go into the new `libgit2` directory, you'll see the project files in there, ready to be worked on or used.
-If you want to clone the repository into a directory named something other than ``libgit2'', you can specify that as the next command-line option:
+If you want to clone the repository into a directory named something other than `libgit2`, you can specify the new directory name as an additional argument:
 //////////////////////////
-これは、まず``libgit2''というディレクトリを作成してその中で `.git` ディレクトリを初期化し、リポジトリのすべてのデータを引き出し、そして最新バージョンの作業コピーをチェックアウトします。
+これは、まず `libgit2` というディレクトリを作成してその中で `.git` ディレクトリを初期化し、リポジトリのすべてのデータを引き出し、そして最新バージョンの作業コピーをチェックアウトします。
 新しくできた `libgit2` ディレクトリに入ると、プロジェクトのファイルをごらんいただけます。
-もし``libgit2''ではない別の名前のディレクトリにクローンしたいのなら、コマンドラインオプションでディレクトリ名を指定します。
+もし `libgit2` ではない別の名前のディレクトリにクローンしたいのなら、コマンドラインオプションでディレクトリ名を指定します。
 
 [source,console]
 ----

--- a/book/10-git-internals/sections/objects.asc
+++ b/book/10-git-internals/sections/objects.asc
@@ -235,10 +235,10 @@ Then, you specify the mode, SHA-1, and filename:
 自前でツリーを作るのも非常に簡単です。
 Gitは通常、ステージングエリアやインデックスの状態を取得してツリーを作成し、そのツリーをもとに一連のツリーオブジェクトを書き込みます。
 そのため、ツリーオブジェクトを作るには、まずファイルをステージングしてインデックスを作成しなければなりません。
-単一のエントリー – ここでは`test.txt`ファイルの最初のバージョン – からインデックスを作るには、`update-index` という配管コマンドを使います。
-このコマンドは、前のバージョンの`test.txt`ファイルをあえて新しいステージングエリアに追加する際に使用します。
+単一のエントリー – ここでは `test.txt` ファイルの最初のバージョン – からインデックスを作るには、`update-index` という配管コマンドを使います。
+このコマンドは、前のバージョンの `test.txt` ファイルをあえて新しいステージングエリアに追加する際に使用します。
 ファイルはまだステージングエリアには存在しない（まだステージングエリアをセットアップさえしていない）ので、`--add` オプションを付けなければなりません。
-また、追加しようとしているファイルはディレクトリには無くデータベースにあるので、`--cacheinfo`オプションを付ける必要があります。
+また、追加しようとしているファイルはディレクトリには無くデータベースにあるので、`--cacheinfo` オプションを付ける必要があります。
 その次に、モード、SHA-1、ファイル名を指定します。
 
 [source,console]
@@ -285,7 +285,7 @@ tree
 //////////////////////////
 You'll now create a new tree with the second version of `test.txt` and a new file as well:
 //////////////////////////
-今度は、2つめのバージョンの`test.txt`と、新規作成したファイルから、新しくツリーを作ります。
+今度は、2つめのバージョンの `test.txt` と、新規作成したファイルから、新しくツリーを作ります。
 
 [source,console]
 ----
@@ -298,7 +298,7 @@ $ git update-index --add new.txt
 Your staging area now has the new version of `test.txt` as well as the new file `new.txt`.
 Write out that tree (recording the state of the staging area or index to a tree object) and see what it looks like:
 //////////////////////////
-これでステージングエリアには、`new.txt`という新しいファイルに加えて、新しいバージョンの`test.txt`も登録されました。
+これでステージングエリアには、 `new.txt` という新しいファイルに加えて、新しいバージョンの `test.txt` も登録されました。
 このツリーを書き出して（ステージングエリアまたはインデックスの状態をツリーオブジェクトとして記録して）、どのようになったか見てみましょう。
 
 [source,console]
@@ -311,12 +311,12 @@ $ git cat-file -p 0155eb4229851634a0f03eb265b69f5a2d56f341
 ----
 
 //////////////////////////
-Notice that this tree has both file entries and also that the `test.txt` SHA-1 is the ``version 2'' SHA-1 from earlier (`1f7a7a`).
+Notice that this tree has both file entries and also that the `test.txt` SHA-1 is the "`version 2`" SHA-1 from earlier (`1f7a7a`).
 Just for fun, you'll add the first tree as a subdirectory into this one.
 You can read trees into your staging area by calling `read-tree`.
 In this case, you can read an existing tree into your staging area as a subtree by using the `--prefix` option to `read-tree`:
 //////////////////////////
-このツリーに両方のファイルエントリがあること、また、`test.txt`のSHA-1が先ほどの ``version 2'' のSHA-1（`1f7a7a`）であることに注意してください。
+このツリーに両方のファイルエントリがあること、また、`test.txt` のSHA-1が先ほどの "`version 2`" のSHA-1（ `1f7a7a` ）であることに注意してください。
 ちょっと試しに、最初のツリーをサブディレクトリとしてこの中に追加してみましょう。
 `read-tree` を呼ぶことで、ステージングエリアの中にツリーを読み込むことができます。
 このケースでは、`--prefix` オプションを付けて `read-tree` コマンドを使用することで、ステージングエリアの中に、既存のツリーをサブツリーとして読み込むことができます。
@@ -336,7 +336,7 @@ $ git cat-file -p 3c4e9cd789d88d8d89c1073707c3585e41b0e614
 If you created a working directory from the new tree you just wrote, you would get the two files in the top level of the working directory and a subdirectory named `bak` that contained the first version of the `test.txt` file.
 You can think of the data that Git contains for these structures as being like this:
 //////////////////////////
-先ほど書き込んだ新しいツリーから作業ディレクトリを作っていれば、作業ディレクトリの直下にファイルが2つと、最初のバージョンの`test.txt`ファイルが含まれている `bak` という名前のサブディレクトリが入ります。
+先ほど書き込んだ新しいツリーから作業ディレクトリを作っていれば、作業ディレクトリの直下にファイルが2つと、最初のバージョンの `test.txt` ファイルが含まれている `bak` という名前のサブディレクトリが入ります。
 このような構成に対し、Gitが格納するデータのイメージは次のようになります。
 
 //////////////////////////

--- a/book/10-git-internals/sections/transfer-protocols.asc
+++ b/book/10-git-internals/sections/transfer-protocols.asc
@@ -247,7 +247,7 @@ The `git-receive-pack` command immediately responds with one line for each refer
 The first line also has a list of the server's capabilities (here, `report-status`, `delete-refs`, and some others, including the client identifier).
 //////////////////////////
 `git-receive-pack` コマンドは、今ある参照1つにつき1行の応答を、その都度返します。このケースでは、`master` ブランチとそのSHA-1ハッシュのみを返しています。
-最初の行には、サーバーの持っている機能（ここでは、`report-status` や `delete-refs`など。クライアント識別子も含む）のリストも含まれています。
+最初の行には、サーバーの持っている機能（ここでは、`report-status` や `delete-refs` など。クライアント識別子も含む）のリストも含まれています。
 
 //////////////////////////
 Each line starts with a 4-character hex value specifying how long the rest of the line is.


### PR DESCRIPTION
Hi,

This is a series of corrections for issues that some markups are not detected in following sections:

- book/02-git-basics/sections/getting-a-repository.asc [HTML](https://git-scm.com/book/ja/v2/Git-%E3%81%AE%E5%9F%BA%E6%9C%AC-Git-%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E3%81%AE%E5%8F%96%E5%BE%97)
- book/10-git-internals/sections/objects.asc [HTML](https://git-scm.com/book/ja/v2/Git%E3%81%AE%E5%86%85%E5%81%B4-Git%E3%82%AA%E3%83%96%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88)
- book/10-git-internals/sections/transfer-protocols.asc [HTML](https://git-scm.com/book/ja/v2/Git%E3%81%AE%E5%86%85%E5%81%B4-%E8%BB%A2%E9%80%81%E3%83%97%E3%83%AD%E3%83%88%E3%82%B3%E3%83%AB)

Also, this includes a minor correction (libgit -> libgit2).

Could you please review?

Many thanks