### PR TITLE
Insert spaces around backticks for markups to be correctly detected

### DIFF
--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -266,7 +266,7 @@ If you run `git status -s` or `git status --short` you get a far more simplified
 //////////////////////////
 `git status` の出力はとてもわかりやすいですが、一方で冗長でもあります。
 Gitにはそれを簡略化するためのオプションもあり、変更点をより簡潔に確認できます。
-`git status -s`や`git status --short`コマンドを実行して、簡略化された状態表示を見てみましょう。
+`git status -s` や `git status --short` コマンドを実行して、簡略化された状態表示を見てみましょう。
 
 [source,console]
 ----
@@ -284,11 +284,11 @@ There are two columns to the output - the left hand column indicates that the fi
 So for example in that output, the `README` file is modified in the working directory but not yet staged, while the `lib/simplegit.rb` file is modified and staged.
 The `Rakefile` was modified, staged and then modified again, so there are changes to it that are both staged and unstaged.
 //////////////////////////
-まだ追跡されていない新しいファイルには`??`が、ステージングエリアに追加されたファイルには`A`が、変更されたファイルには`M`が、といったように、ファイル名の左側に文字列が表示されます。
+まだ追跡されていない新しいファイルには `??` が、ステージングエリアに追加されたファイルには `A` が、変更されたファイルには `M` が、といったように、ファイル名の左側に文字列が表示されます。
 内容は2文字の組み合わせです。1文字目はステージされたファイルの状態を、2文字はファイルが変更されたかどうかを示しています。
-この例でいうと、`README`ファイルは作業ディレクトリ上にあって変更されているけれどステージされてはいません。
-`lib/simplegit.rb`ファイルは変更済みでステージもされています。
-`Rakefile`のほうはどうかというと、変更されステージされたあと、また変更された、という状態です。変更の内容にステージされたものとそうでないものがあることになります。
+この例でいうと、`README` ファイルは作業ディレクトリ上にあって変更されているけれどステージされてはいません。
+`lib/simplegit.rb` ファイルは変更済みでステージもされています。
+`Rakefile` のほうはどうかというと、変更されステージされたあと、また変更された、という状態です。変更の内容にステージされたものとそうでないものがあることになります。
 
 [[r_ignoring]]
 //////////////////////////
@@ -352,7 +352,7 @@ glob パターンとは、シェルで用いる簡易正規表現のようなも
 また、ハイフン区切りの文字を角括弧で囲んだ形式 (`[0-9]`) は、
 ふたつの文字の間の任意の文字 (この場合は 0 から 9 までの間の文字) にマッチします。
 アスタリクスを2つ続けて、ネストされたディレクトリにマッチさせることもできます。
-`a/**/z` のように書けば、`a/z`、`a/b/z`、`a/b/c/z`などにマッチします。
+`a/**/z` のように書けば、`a/z`、`a/b/z`、`a/b/c/z` などにマッチします。
 
 //////////////////////////
 Here is another example .gitignore file:
@@ -577,10 +577,10 @@ Run `git difftool --tool-help` to see what is available on your system.
 //////////////////////////
 .GitのDiffを他のツールで見る
 ====
-この本では、引き続き`git diff`コマンドを様々な方法で使っていきます。
+この本では、引き続き `git diff` コマンドを様々な方法で使っていきます。
 一方、このコマンドを使わずに差分を見る方法も用意されています。GUIベースだったり、他のツールが好みの場合、役に立つでしょう。
-`git diff`の代わりに`git difftool`を実行してください。そうすれば、emerge、vimdiffなどのツールを使って差分を見られます（商用のツールもいくつもあります）。
-また、`git difftool --tool-help`を実行すれば、利用可能なdiffツールを確認することもできます。
+`git diff` の代わりに `git difftool` を実行してください。そうすれば、emerge、vimdiffなどのツールを使って差分を見られます（商用のツールもいくつもあります）。
+また、`git difftool --tool-help` を実行すれば、利用可能なdiffツールを確認することもできます。
 ====
 
 [[r_committing_changes]]

--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -174,14 +174,14 @@ Changes not staged for commit:
 ----
 
 //////////////////////////
-The `CONTRIBUTING.md` file appears under a section named ``Changes not staged for commit'' – which means that a file that is tracked has been modified in the working directory but not yet staged.
+The `CONTRIBUTING.md` file appears under a section named "`Changes not staged for commit`" -- which means that a file that is tracked has been modified in the working directory but not yet staged.
 To stage it, you run the `git add` command.
 `git add` is a multipurpose command – you use it to begin tracking new files, to stage files, and to do other things like marking merge-conflicted files as resolved.
-It may be helpful to think of it more as ``add this content to the next commit'' rather than ``add this file to the project''.(((git commands, add)))
+It may be helpful to think of it more as "`add this content to the next commit`" rather than "`add this file to the project`".(((git commands, add)))
 Let's run `git add` now to stage the `CONTRIBUTING.md` file, and then run `git status` again:
 //////////////////////////
-`CONTRIBUTING.md` ファイルは ``Changed but not staged for commit'' という欄に表示されます。これは、追跡対象のファイルが作業ディレクトリ内で変更されたけれどもまだステージされていないという意味です。
-ステージするには `git add` コマンドを実行します。 `git add` にはいろんな意味合いがあり、新しいファイルの追跡開始・ファイルのステージング・マージ時に衝突が発生したファイルに対する「解決済み」マーク付けなどで使用します。``指定したファイルをプロジェクトに追加(add)する''コマンド、というよりは、``指定した内容を次のコミットに追加(add)する''コマンド、と捉えるほうがわかりやすいかもしれません。(((git commands, add)))
+`CONTRIBUTING.md` ファイルは "`Changed but not staged for commit`" という欄に表示されます。これは、追跡対象のファイルが作業ディレクトリ内で変更されたけれどもまだステージされていないという意味です。
+ステージするには `git add` コマンドを実行します。 `git add` にはいろんな意味合いがあり、新しいファイルの追跡開始・ファイルのステージング・マージ時に衝突が発生したファイルに対する「解決済み」マーク付けなどで使用します。 "`指定したファイルをプロジェクトに追加(add)する`" コマンド、というよりは、 "`指定した内容を次のコミットに追加(add)する`" コマンド、と捉えるほうがわかりやすいかもしれません。(((git commands, add)))
 では、`git add` で `CONTRIBUTING.md` をステージしてもういちど `git status` を実行してみましょう。
 
 [source,console]

--- a/book/09-git-and-other-scms/sections/import-svn.asc
+++ b/book/09-git-and-other-scms/sections/import-svn.asc
@@ -133,7 +133,7 @@ $ rm -Rf .git/refs/remotes/origin
 //////////////////////////
 It may happen that you'll see some extra branches which are suffixed by `@xxx` (where xxx is a number), while in Subversion you only see one branch. This is actually a Subversion feature called "peg-revisions", which is something that Git simply has no syntactical counterpart for. Hence, `git svn` simply adds the svn version number to the branch name just in the same way as you would have written it in svn to address the peg-revision of that branch. If you do not care anymore about the peg-revisions, simply remove them using `git branch -d`.
 //////////////////////////
-このとき、Subversionではブランチが1つだったのにもかかわらず、名前が`@xxx`（xxxは数字）で終わる余分なブランチがいくつか出来てしまうことがあります。Subversionの「ペグ・リビジョン」という機能が原因なのですが、Gitにはこれと同等の機能は存在しません。よって、`git svn`コマンドはブランチ名にsvnのバージョン番号をそのまま追加します。svnでペグ・リビジョンをブランチに設定するときとまさに同じやり方です。もうペグ・リビジョンがいらないのであれば、`git branch -d`コマンドで削除してしまいましょう。
+このとき、Subversionではブランチが1つだったのにもかかわらず、名前が `@xxx`（xxxは数字）で終わる余分なブランチがいくつか出来てしまうことがあります。Subversionの「ペグ・リビジョン」という機能が原因なのですが、Gitにはこれと同等の機能は存在しません。よって、`git svn` コマンドはブランチ名にsvnのバージョン番号をそのまま追加します。svnでペグ・リビジョンをブランチに設定するときとまさに同じやり方です。もうペグ・リビジョンがいらないのであれば、`git branch -d` コマンドで削除してしまいましょう。
 
 //////////////////////////
 Now all the old branches are real Git branches and all the old tags are real Git tags.
@@ -143,7 +143,7 @@ Now all the old branches are real Git branches and all the old tags are real Git
 //////////////////////////
 There's one last thing to clean up. Unfortunately, `git svn` creates an extra branch named `trunk`, which maps to Subversion's default branch, but the `trunk` ref points to the same place as `master`. Since `master` is more idiomatically Git, here's how to remove the extra branch:
 //////////////////////////
-最後に後始末についてです。残念なことに、`git svn`は`trunk`という名前の余計なブランチを生成してしまいます。Subversionにおけるデフォルトブランチではあるのですが、`trunk`の参照が指す場所は`master`と同じです。`master`のほうが用語としてもGitらしいですから、余分なブランチは削除してしまいましょう。
+最後に後始末についてです。残念なことに、`git svn` は `trunk` という名前の余計なブランチを生成してしまいます。Subversionにおけるデフォルトブランチではあるのですが、`trunk` の参照が指す場所は `master` と同じです。`master` のほうが用語としてもGitらしいですから、余分なブランチは削除してしまいましょう。
 
 [source,console]
 ----

--- a/book/A-git-in-other-environments/sections/guis.asc
+++ b/book/A-git-in-other-environments/sections/guis.asc
@@ -74,8 +74,8 @@ Gitkのインターフェイスは次のようになっています。
 .The `gitk` history viewer.
 image::images/gitk.png[The `gitk` history viewer.]
 //////////////////////////
-.`gitk`の歴史ビューアー
-image::images/gitk.png[`gitk`の歴史ビューアー]
+.`gitk` の歴史ビューアー
+image::images/gitk.png[`gitk` の歴史ビューアー]
 
 //////////////////////////
 On the top is something that looks a bit like the output of `git log --graph`; each dot represents a commit, the lines represent parent relationships, and refs are shown as colored boxes.

--- a/book/A-git-in-other-environments/sections/guis.asc
+++ b/book/A-git-in-other-environments/sections/guis.asc
@@ -181,13 +181,13 @@ We won't be doing a detailed rundown of these tools (they have their own documen
 ここではツールの詳細な説明はしません（GitHubクライアントの自前のドキュメントがあります）が、 ``changes'' ビュー（ツールの実行時間の大半はここを使うことになると思います）の内容をざっと見ていきましょう。
 
 //////////////////////////
-* On the left is the list of repositories the client is tracking; you can add a repository (either by cloning or attaching locally) by clicking the ``+'' icon at the top of this area.
+* On the left is the list of repositories the client is tracking; you can add a repository (either by cloning or attaching locally) by clicking the "`+`" icon at the top of this area.
 * In the center is a commit-input area, which lets you input a commit message, and select which files should be included.
   (On Windows, the commit history is displayed directly below this; on Mac, it's on a separate tab.)
 * On the right is a diff view, which shows what's changed in your working directory, or which changes were included in the selected commit.
 * The last thing to notice is the ``Sync'' button at the top-right, which is the primary way you interact over the network.
 //////////////////////////
-* 左側には、クライアントが追跡しているリポジトリのリストが表示されます。この領域の一番上の ``+ '' アイコンをクリックすると、（ローカルでクローンするかアタッチするかして）リポジトリを追加できます。
+* 左側には、クライアントが追跡しているリポジトリのリストが表示されます。この領域の一番上の "`+`" アイコンをクリックすると、（ローカルでクローンするかアタッチするかして）リポジトリを追加できます。
 * 真ん中はコミット入力領域です。コミットメッセージを入力したり、コミットに含めるファイルを選択したりできます。
   （Windowsでは、コミットの歴史は、この下に直接表示されます。Macの場合は、別のタブに表示されます。）
 * 右側はdiffビューです。作業ディレクトリの変更内容、または、選択しているコミットに含まれている内容が表示されます。

--- a/book/A-git-in-other-environments/sections/powershell.asc
+++ b/book/A-git-in-other-environments/sections/powershell.asc
@@ -50,4 +50,4 @@ Windows用GitHubクライアントのユーザでない場合は、 (https://git
 //////////////////////////
 This will add the proper line to your `profile.ps1` file, and posh-git will be active the next time you open your prompt.
 //////////////////////////
-これで `profile.ps1`ファイルに適切な内容が追加されます。次にプロンプトを開いた時に、 posh-git が有効になります。
+これで `profile.ps1` ファイルに適切な内容が追加されます。次にプロンプトを開いた時に、 posh-git が有効になります。

--- a/book/A-git-in-other-environments/sections/zsh.asc
+++ b/book/A-git-in-other-environments/sections/zsh.asc
@@ -10,7 +10,7 @@ To use it, simply run `autoload -Uz compinit && compinit` in your `.zshrc`.
 Zsh's interface is a bit more powerful than Bash's:
 //////////////////////////
 Zshには、Git用のタブ補完ライブラリも同梱されています。
-`.zshrc`に`autoload -Uz compinit && compinit`という行を追加するだけで、使えるようになります。
+`.zshrc` に `autoload -Uz compinit && compinit` という行を追加するだけで、使えるようになります。
 Zshのインターフェイスは、Bashよりさらに強力です。
 
 [source,console]
@@ -70,14 +70,14 @@ For more information on vcs_info, check out its documentation
         in the `zshcontrib(1)` manual page,
         or online at http://zsh.sourceforge.net/Doc/Release/User-Contributions.html#Version-Control-Information[].
 //////////////////////////
-vcs_infoについての詳細は、`zshcontrib(1)`マニュアルにあるドキュメントか、オンラインであれば http://zsh.sourceforge.net/Doc/Release/User-Contributions.html#Version-Control-Information[] を確認してみてください。
+vcs_infoについての詳細は、`zshcontrib(1)` マニュアルにあるドキュメントか、オンラインであれば http://zsh.sourceforge.net/Doc/Release/User-Contributions.html#Version-Control-Information[] を確認してみてください。
 
 //////////////////////////
 Instead of vcs_info, you might prefer the prompt customization script that ships with Git, called `git-prompt.sh`; see https://github.com/git/git/blob/master/contrib/completion/git-prompt.sh[] for details.
 `git-prompt.sh` is compatible with both Bash and Zsh.
 //////////////////////////
-一方、Gitに同梱されている`git-prompt.sh`というスクリプトでも、プロンプトをカスタマイズすることができます。vcs_infoよりも気に入るかもしれませんね。詳しくは https://github.com/git/git/blob/master/contrib/completion/git-prompt.sh[] を確認してみてください。
-`git-prompt.sh`はBashとZshの両方に対応しています。
+一方、Gitに同梱されている `git-prompt.sh` というスクリプトでも、プロンプトをカスタマイズすることができます。vcs_infoよりも気に入るかもしれませんね。詳しくは https://github.com/git/git/blob/master/contrib/completion/git-prompt.sh[] を確認してみてください。
+`git-prompt.sh` はBashとZshの両方に対応しています。
 
 //////////////////////////
 Zsh is powerful enough that there are entire frameworks dedicated to making it better.

--- a/book/B-embedding-git/sections/jgit.asc
+++ b/book/B-embedding-git/sections/jgit.asc
@@ -277,7 +277,7 @@ In this case, we're asking the `origin` remote for tags, but not heads.
 Also notice the use of a `CredentialsProvider` object for authentication.
 //////////////////////////
 これはGitクラスを使うときによくあるパターンです。メソッドがコマンドオブジェクトを返すので、パラメータを設定するメソッドチェーンを繋げていき、最後に `.call()` メソッドを呼び出すとそれらがまとめて実行されます。
-このケースでは、タグを取得する際に、HEADではなく`origin`リモートを要求しています。
+このケースでは、タグを取得する際に、HEADではなく `origin` リモートを要求しています。
 また、`CredentialsProvider` オブジェクトを使って認証を行っていることにも注意してください。
 
 //////////////////////////


### PR DESCRIPTION
Hi,

This is a series of corrections for issues that some markups are not detected in following sections:

- book/02-git-basics/sections/recording-changes.asc [HTML](https://git-scm.com/book/ja/v2/Git-%E3%81%AE%E5%9F%BA%E6%9C%AC-%E5%A4%89%E6%9B%B4%E5%86%85%E5%AE%B9%E3%81%AE%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E3%81%B8%E3%81%AE%E8%A8%98%E9%8C%B2)
- book/09-git-and-other-scms/sections/import-svn.asc [HTML](https://git-scm.com/book/ja/v2/Git%E3%81%A8%E3%81%9D%E3%81%AE%E4%BB%96%E3%81%AE%E3%82%B7%E3%82%B9%E3%83%86%E3%83%A0%E3%81%AE%E9%80%A3%E6%90%BA-Git-%E3%81%B8%E7%A7%BB%E8%A1%8C%E3%81%99%E3%82%8B)
- book/A-git-in-other-environments/sections/*.asc [HTML](https://git-scm.com/book/ja/v2/%E4%BB%98%E9%8C%B2-A%3A-%E3%81%9D%E3%81%AE%E4%BB%96%E3%81%AE%E7%92%B0%E5%A2%83%E3%81%A7%E3%81%AEGit-%E3%82%B0%E3%83%A9%E3%83%95%E3%82%A3%E3%82%AB%E3%83%AB%E3%82%A4%E3%83%B3%E3%82%BF%E3%83%95%E3%82%A7%E3%83%BC%E3%82%B9)
- book/B-embedding-git/sections/jgit.asc [HTML](https://git-scm.com/book/ja/v2/%E4%BB%98%E9%8C%B2-B%3A-Git%E3%82%92%E3%81%82%E3%81%AA%E3%81%9F%E3%81%AE%E3%82%A2%E3%83%97%E3%83%AA%E3%82%B1%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%AB%E7%B5%84%E3%81%BF%E8%BE%BC%E3%82%80-JGit)

Could you please review?

Many thanks