### PR TITLE
Fix wrong translation

### DIFF
--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -36,7 +36,7 @@ Gitには、`git config`と呼ばれるツールが付属します。これで�
 //////////////////////////
 Each level overrides values in the previous level, so values in `.git/config` trump those in `/etc/gitconfig`.
 //////////////////////////
-それぞれのレベルの値は以前のレベルの値を上書きするため、`.git/config`の中の設定値は`/etc/gitconfig`の設定値に優先されます。
+それぞれのレベルの値は以前のレベルの値を上書きするため、`.git/config`の中の設定値は`/etc/gitconfig`の設定値よりも優先されます。
 
 //////////////////////////
 On Windows systems, Git looks for the `.gitconfig` file in the `$HOME` directory (`C:\Users\$USER` for most people).

--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -17,7 +17,7 @@ You can also change them at any time by running through the commands again.
 Git comes with a tool called `git config` that lets you get and set configuration variables that control all aspects of how Git looks and operates.(((git commands, config)))
 These variables can be stored in three different places:
 //////////////////////////
-Gitには、`git config`と呼ばれるツールが付属します。これで、どのようにGitが見えて機能するかの全ての面を制御できる設定変数を取得し、設定することができます。(((git commands, config)))
+Gitには、`git config` と呼ばれるツールが付属します。これで、どのようにGitが見えて機能するかの全ての面を制御できる設定変数を取得し、設定することができます。(((git commands, config)))
 これらの変数は三つの異なる場所に格納されうります：
 
 //////////////////////////
@@ -28,15 +28,15 @@ Gitには、`git config`と呼ばれるツールが付属します。これで�
 3. `config` file in the Git directory (that is, `.git/config`) of whatever repository you're currently using: Specific to that single repository.
 //////////////////////////
 1. `/etc/gitconfig` ファイル: システム上の全てのユーザーと全てのリポジトリに対する設定値を保持します。
-  もし`--system`オプションを`git config`に指定すると、明確にこのファイルに読み書きを行ないます。
+  もし `--system` オプションを `git config` に指定すると、明確にこのファイルに読み書きを行ないます。
 2. `~/.gitconfig` か `~/.config/git/config` ファイル: 特定のユーザーに対する設定値を保持します。
-  `--global`オプションを指定することで、Gitに、明確にこのファイルに読み書きを行なわせることができます。
-3. 現在使っているリポジトリのGitディレクトリにある`config`ファイル(`.git/config`のことです): 特定の単一リポジトリに対する設定値を保持します。
+   `--global` オプションを指定することで、Gitに、明確にこのファイルに読み書きを行なわせることができます。
+3. 現在使っているリポジトリのGitディレクトリにある `config` ファイル( `.git/config` のことです): 特定の単一リポジトリに対する設定値を保持します。
 
 //////////////////////////
 Each level overrides values in the previous level, so values in `.git/config` trump those in `/etc/gitconfig`.
 //////////////////////////
-それぞれのレベルの値は以前のレベルの値を上書きするため、`.git/config`の中の設定値は`/etc/gitconfig`の設定値よりも優先されます。
+それぞれのレベルの値は以前のレベルの値を上書きするため、`.git/config` の中の設定値は `/etc/gitconfig` の設定値よりも優先されます。
 
 //////////////////////////
 On Windows systems, Git looks for the `.gitconfig` file in the `$HOME` directory (`C:\Users\$USER` for most people).
@@ -73,8 +73,8 @@ Again, you need to do this only once if you pass the `--global` option, because 
 <<<<<<< HEAD
 If you want to override this with a different name or email address for specific projects, you can run the command without the `--global` option when you're in that project.
 //////////////////////////
-また、もし`--global`オプションを指定するのであれば、Gitはその後、そのシステム上で行なう（訳者注：あるユーザーの）全ての操作に対して常にこの情報を使うようになるため、この操作を行なう必要はたった一度だけです。
-もし、違う名前とEmailアドレスを特定のプロジェクトで上書きしたいのであれば、そのプロジェクトの（訳者注：Gitディレクトリの）中で、`--global`オプション無しでこのコマンドを実行することができます。
+また、もし `--global` オプションを指定するのであれば、Gitはその後、そのシステム上で行なう（訳者注：あるユーザーの）全ての操作に対して常にこの情報を使うようになるため、この操作を行なう必要はたった一度だけです。
+もし、違う名前とEmailアドレスを特定のプロジェクトで上書きしたいのであれば、そのプロジェクトの（訳者注：Gitディレクトリの）中で、`--global` オプション無しでこのコマンドを実行することができます。
 
 //////////////////////////
 Many of the GUI tools will help you do this when you first run them.
@@ -154,7 +154,7 @@ Git用のエディターを設定していなくて、Gitを使っている最�
 //////////////////////////
 If you want to check your settings, you can use the `git config --list` command to list all the settings Git can find at that point:
 //////////////////////////
-設定を確認したい場合は、その時点でGitが見つけられる全ての設定を一覧するコマンドである`git config --list`を使う事ができます：
+設定を確認したい場合は、その時点でGitが見つけられる全ての設定を一覧するコマンドである `git config --list` を使う事ができます：
 
 [source,console]
 ----
@@ -172,12 +172,12 @@ color.diff=auto
 You may see keys more than once, because Git reads the same key from different files (`/etc/gitconfig` and `~/.gitconfig`, for example).
 In this case, Git uses the last value for each unique key it sees.
 //////////////////////////
-Gitは異なったファイル(例えば`/etc/gitconfig`と`~/.gitconfig`)から同一のキーを読み込むため、同一のキーを1度以上見ることになるでしょう。この場合、Gitは見つけたそれぞれ同一のキーに対して最後の値を用います。
+Gitは異なったファイル(例えば `/etc/gitconfig` と `~/.gitconfig` )から同一のキーを読み込むため、同一のキーを1度以上見ることになるでしょう。この場合、Gitは見つけたそれぞれ同一のキーに対して最後の値を用います。
 
 //////////////////////////
 You can also check what Git thinks a specific key's value is by typing `git config <key>`:(((git commands, config)))
 //////////////////////////
-また、Gitに設定されている特定のキーの値を、`git config <key>`とタイプすることで確認することができます：(((git commands, config)))
+また、Gitに設定されている特定のキーの値を、`git config <key>` とタイプすることで確認することができます：(((git commands, config)))
 
 [source,console]
 ----


### PR DESCRIPTION
### 概要
意味が反対になっている部分があったので修正しました。

### 詳細
原文：
> Each level overrides values in the previous level, so values in .git/config trump those in [path]/etc/gitconfig.

元の翻訳：
> それぞれのレベルの値は以前のレベルの値を上書きするため、`.git/config` の中の設定値は `/etc/gitconfig` の設定値に優先されます。

修正後の翻訳：
> それぞれのレベルの値は以前のレベルの値を上書きするため、`.git/config` の中の設定値は `/etc/gitconfig` の設定値よりも優先されます。

原文では、「`.git/config` の設定値の方が `/etc/gitconfig` の設定値より優先度が高い」ということを述べています。
一方、元の翻訳では、「AはBに優先する」は「AはBより優先度が高い」という意味で、かつ述語が受け身となっているため、原文とは反対の意味となってしまっています。
そのため、元の翻訳を”に”→”よりも”と変更することにより、原文と同じ意味にしました。

### その他の微修正
バッククォートが上手く機能していなかったので、バッククォート周辺にスペースを挿入しました。